### PR TITLE
spec.name is too long in azure to use k3s

### DIFF
--- a/jobs/k3s-agent/templates/bin/ctl.erb
+++ b/jobs/k3s-agent/templates/bin/ctl.erb
@@ -76,10 +76,10 @@ case $1 in
     --node-ip=<%= spec.ip %> \
     --node-external-ip=<%= spec.ip != spec.networks.marshal_dump.values.first.ip ? spec.networks.marshal_dump.values.first.ip : spec.networks.marshal_dump.values.last.ip %> \
     --node-label bosh.io/az=<%= spec.az %> \
-    --node-label bosh.io/name=<%= spec.name %>  \
+    --node-label bosh.io/name=<%= spec.name %> \
     --node-label bosh.io/bootstrap=<%= spec.bootstrap %>  \
     --node-label bosh.io/index=<%= spec.index %>  \
-    --node-label bosh.io/address=<%= spec.address %>  \
+    --node-label bosh.io/address=<%= spec.ip %>  \
     --node-label topology.kubernetes.io/zone=<%= spec.az %> \
       $FLAGS \
       $servers \

--- a/jobs/k3s-server/spec
+++ b/jobs/k3s-server/spec
@@ -10,7 +10,6 @@ templates:
   bin/pre-start.erb: bin/pre-start
   bin/post-start.erb: bin/post-start  
   bin/pre-stop.erb: bin/pre-stop
-  bin/pre-stop.erb: bin/pre-stop
   bin/post-deploy.erb: bin/post-deploy
   bin/drain.erb: bin/drain
   bin/ctl.erb: bin/ctl

--- a/jobs/k3s-server/templates/bin/ctl.erb
+++ b/jobs/k3s-server/templates/bin/ctl.erb
@@ -119,10 +119,10 @@ case $1 in
     --tls-san=<%= spec.networks.send(spec.networks.methods(false).first).dns_record_name %> \
     --node-external-ip=<%= spec.ip %> \
     --node-label bosh.io/az=<%= spec.az %> \
-    --node-label bosh.io/name=<%= spec.name %>  \
+    --node-label bosh.io/name=<%= spec.name %> \
     --node-label bosh.io/bootstrap=<%= spec.bootstrap %>  \
     --node-label bosh.io/index=<%= spec.index %>  \
-    --node-label bosh.io/address=<%= spec.address %>  \
+    --node-label bosh.io/address=<%= spec.ip %>  \
     --node-label topology.kubernetes.io/zone=<%= spec.az %> \
       $FLAGS \
       >>  $LOG_DIR/k3s-server.stdout.log \


### PR DESCRIPTION
hi @poblin-orange 

I'm not sure if you'll find this useful or not but on azure some of the fields are too long to be k8s labels. I modified your work a bit.